### PR TITLE
refactor: externalize assessment templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.1.0] - 2025-09-24
+
+### Added
+
+- **Assessment Template Registry**: Bundled GDPR/social engineering course template exposed through Pydantic schemas and new `/api/v1/assessment/schema` endpoints.
+- **Template SPOT Documentation**: Introduced `docs/SPOT_Assessments.md` linking code, data, and API touchpoints for assessment templates.
+- **Automated Tests**: Added coverage ensuring template listings, detail retrieval, and error handling behave as expected.
+
+### Changed
+
+- **Container Stack**: Replaced the plain Postgres service with a Supabase Postgres container to align with production infrastructure plans.
+- **Template Registry Layout**: Moved bundled definitions into `app/assessment_templates` JSON resources loaded through a typed registry for clarity and reuse.
+- **Developer Documentation**: Updated guides and README to surface the template schema endpoints and Supabase connection details.
+
+### Fixed
+
+- Ensured template serialization preserves JSON field aliases (e.g., `time_window.from`) via central schema validation.
+
+---
+
 ## [3.0.0] - 2025-07-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ const assessmentHistory = await getAssessmentHistory(token);
 - `POST /api/v1/lead-capture/capture-lead` - Create user account
 - `POST /api/v1/assessment/start` - Start new assessment
 - `GET /api/v1/assessment/data/full` - Load questions
+- `GET /api/v1/assessment/schema` - List bundled assessment templates
+- `GET /api/v1/assessment/schema/{template_id}` - Retrieve full template definition
 
 ### Protected Endpoints (Authentication Required)
 - `POST /api/v1/assessment/submit` - Submit assessment answers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     # expose:
     #   - "8000"
     depends_on:
-      db:
+      supabase-db:
         condition: service_healthy
       redis:
         condition: service_started
@@ -30,7 +30,7 @@ services:
     env_file:
       - ./src/.env
     depends_on:
-      db:
+      supabase-db:
         condition: service_healthy
       redis:
         condition: service_started
@@ -38,18 +38,21 @@ services:
       - ./src/app:/code/app
       - ./src/.env:/code/.env
 
-  db:
-    image: postgres:13
+  supabase-db:
+    image: supabase/postgres:15.1.1.65
     env_file:
       - ./src/.env
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_PORT: 5432
+      PGPORT: 5432
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - supabase-data:/var/lib/postgresql/data
       - ./seed_scripts:/docker-entrypoint-initdb.d
-    # -------- replace with comment to run migrations with docker --------
     expose:
       - "5432"
-    # ports:
-    #  - 5432:5432
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
       interval: 5s
@@ -75,7 +78,7 @@ services:
   #   env_file:
   #     - ./src/.env
   #   depends_on:
-  #     - db
+  #     - supabase-db
 
   #-------- uncomment to run with nginx --------
   # nginx:
@@ -95,7 +98,7 @@ services:
   #   env_file:
   #     - ./src/.env
   #   depends_on:
-  #     - db
+  #     - supabase-db
   #     - web
   #   command: python -m src.scripts.create_first_superuser
   #   volumes:
@@ -109,13 +112,13 @@ services:
   #   env_file:
   #     - ./src/.env
   #   depends_on:
-  #     - db
+  #     - supabase-db
   #     - web
   #   command: python -m src.scripts.create_first_tier
   #   volumes:
   #     - ./src:/code/src
 
 volumes:
-  postgres-data:
+  supabase-data:
   redis-data:
   #pgadmin-data:

--- a/docs/API_Documentation.md
+++ b/docs/API_Documentation.md
@@ -198,6 +198,12 @@ Get assessment results by ID.
 
 **Response:** Same as submit endpoint response
 
+#### GET `/api/v1/assessment/schema`
+List assessment templates that ship with the platform. Returns concise metadata (`id`, `title`, `version`, etc.).
+
+#### GET `/api/v1/assessment/schema/{template_id}`
+Retrieve the full assessment template definition, including scoring rules, KPIs, UX configuration, and analytics specification.
+
 **Features:**
 - Public access via share_token
 - Protected access for assessment owner

--- a/docs/Assessment_System_Guide.md
+++ b/docs/Assessment_System_Guide.md
@@ -102,6 +102,8 @@ Lead/User → Start Assessment → Answer Questions → Submit → Get Results
 - `GET /api/v1/assessment-data/full` (loads questions)
 - `POST /api/v1/assessments/submit` (calculates scores, generates recommendations)
 - `GET /api/v1/assessments/{id}` (retrieves results)
+- `GET /api/v1/assessment/schema` (lists available template definitions)
+- `GET /api/v1/assessment/schema/{template_id}` (retrieves full template metadata)
 
 ### 3. **User Registration Flow** (Optional)
 ```
@@ -190,6 +192,9 @@ DEFAULT_ASSESSMENT_LIMIT=3
 PREMIUM_ASSESSMENT_LIMIT=50
 SHARE_TOKEN_LENGTH=32
 TEMP_PASSWORD_LENGTH=12
+
+# Supabase container defaults
+POSTGRES_SERVER=supabase-db
 ```
 
 ### Database Migration

--- a/docs/SPOT_Assessments.md
+++ b/docs/SPOT_Assessments.md
@@ -1,0 +1,30 @@
+# SPOT: Assessment Templates & Schema Registry
+
+This Single Point Of Truth (SPOT) keeps the canonical reference for assessment templates that ship with the platform.
+
+## Current Templates
+
+| ID | Version | Title | Notes |
+| --- | --- | --- | --- |
+| `course_gdpr_social_email_cookies_v1_no` | 1.1.0 | GDPR, sosial manipulering, e-post og cookies | Bundled JSON definition validated at load time |
+
+- **Schema models**: `src/app/schemas/assessment_template.py`
+- **Template resources**: `src/app/assessment_templates/definitions/*.json`
+- **Registry module**: `src/app/assessment_templates/registry.py`
+- **API access**:
+  - `GET /api/v1/assessment/schema` — list available templates
+  - `GET /api/v1/assessment/schema/{template_id}` — fetch complete definition
+
+## Implementation Notes
+
+- Template definitions are validated using `AssessmentDefinition` to guarantee contract stability.
+- Responses serialize using field aliases (e.g. `time_window.from`) to stay JSON schema compliant.
+- Add new templates by dropping a JSON file into `src/app/assessment_templates/definitions/` and referencing it from `_TEMPLATE_FILES` in `registry.py`; update this SPOT table in tandem.
+
+## Deployment & Infrastructure
+
+- The development stack now runs against a Supabase Postgres container (`supabase-db`).
+- `.env` configuration continues to drive connection settings—only the host name changed.
+- Docker Compose applies seed scripts automatically, so bundled templates remain available after container rebuilds.
+
+Keep this file synchronized whenever templates or infrastructure touch points evolve.

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,6 +107,7 @@ That's it! Your API will be available at `http://localhost:8000/docs`
 - **[Development](user-guide/development.md)** - Extending and customizing the boilerplate
 - **[Testing](user-guide/testing.md)** - Testing strategies and best practices
 - **[Production](user-guide/production.md)** - Production deployment guides
+- **[Assessment Template SPOT](SPOT_Assessments.md)** - Canonical schema + infrastructure notes
 
 ## Perfect For
 

--- a/src/.env
+++ b/src/.env
@@ -6,7 +6,7 @@ APP_VERSION="0.1.0"
 # Database
 POSTGRES_USER="postgres"
 POSTGRES_PASSWORD="changethis"
-POSTGRES_SERVER="db"
+POSTGRES_SERVER="supabase-db"
 POSTGRES_PORT=5432
 POSTGRES_DB="myapp"
 

--- a/src/app/assessment_templates/__init__.py
+++ b/src/app/assessment_templates/__init__.py
@@ -1,0 +1,8 @@
+"""Assessment template registry and helpers."""
+
+from .registry import get_assessment_template, list_assessment_templates
+
+__all__ = [
+    "get_assessment_template",
+    "list_assessment_templates",
+]

--- a/src/app/assessment_templates/definitions/__init__.py
+++ b/src/app/assessment_templates/definitions/__init__.py
@@ -1,0 +1,1 @@
+"""Bundled assessment template definitions stored as JSON resources."""

--- a/src/app/assessment_templates/definitions/course_gdpr_social_email_cookies_v1_no.json
+++ b/src/app/assessment_templates/definitions/course_gdpr_social_email_cookies_v1_no.json
@@ -1,0 +1,416 @@
+{
+  "id": "course_gdpr_social_email_cookies_v1_no",
+  "version": "1.1.0",
+  "org_id": "11111111-1111-1111-1111-111111111111",
+  "linkage": {
+    "course_id": "crs_gdpr_core_v1",
+    "module_id": "mod_01_gdpr_basics",
+    "assessment_set_id": "aset_gdpr_social_email_cookies_v1"
+  },
+  "meta": {
+    "title": "Kurs: GDPR, sosial manipulering, e-post og cookies (grunnkurs)",
+    "description": "Kort og praktisk vurdering med ekte hverdagsscenarier. Enkel å forstå, god for konvertering.",
+    "estimated_minutes": "8-12",
+    "language": "nb-NO",
+    "visibility": "public",
+    "tags": [
+      "course:gdpr",
+      "phishing",
+      "social-engineering",
+      "email",
+      "cookies"
+    ],
+    "category": "GDPR & Sikkerhet",
+    "difficulty": "Lett–Middels",
+    "audience": "Alle ansatte (spesielt ledelse, HR, salg, kundeservice og drift)",
+    "learning_objectives": [
+      "Forstå grunnleggende GDPR-prinsipper",
+      "Gjenkjenne sosial manipulering og phishing",
+      "Anvende trygg praksis for e-post",
+      "Forklare cookie-samtykke og nødvendighet"
+    ],
+    "regulatory_refs": [
+      {
+        "framework": "GDPR",
+        "article": "Art. 5, 6, 13-15",
+        "topic": null
+      },
+      {
+        "framework": "ePrivacy",
+        "article": null,
+        "topic": "Cookies/samtykke"
+      }
+    ]
+  },
+  "settings": {
+    "lead_magnet": true,
+    "collect_fields": [
+      "name",
+      "email",
+      "company"
+    ],
+    "shuffle_questions": true,
+    "shuffle_options": true,
+    "time_limit_minutes": null,
+    "allow_backtracking": true,
+    "show_explanations": "after_submission",
+    "max_attempts_per_user": 1,
+    "retake_cooldown_hours": 0,
+    "pass_threshold_percentage": 70,
+    "gate_rules": {
+      "require_video_completion_percent": 0,
+      "require_acknowledgement": false
+    }
+  },
+  "ux": {
+    "theme": "light",
+    "progress_bar": true,
+    "question_numbering": "per_section",
+    "accessibility": {
+      "wcag_level": "AA",
+      "caption_required": true,
+      "reading_grade_level": "B1"
+    },
+    "localization": {
+      "default_locale": "nb-NO",
+      "available_locales": [
+        "nb-NO",
+        "en-US"
+      ]
+    }
+  },
+  "security": {
+    "anti_cheat": {
+      "tab_switch_limit": 0,
+      "copy_paste_allowed": true,
+      "suspicious_ip_threshold": 5,
+      "allow_list_domains": []
+    },
+    "proctoring": {
+      "enabled": false,
+      "photo_check": false
+    },
+    "data_protection": {
+      "store_personal_fields_hashed": true,
+      "retain_personal_days": 365
+    }
+  },
+  "integrations": {
+    "webhooks": {
+      "on_pass": null,
+      "on_fail": null,
+      "on_completion": null
+    },
+    "lms": {
+      "scorm": false,
+      "xapi": true
+    },
+    "payments": {
+      "enabled": true,
+      "currency": "NOK",
+      "price_amount": 0,
+      "sku": "GDPR-LEAD-001",
+      "is_free": true
+    }
+  },
+  "categories": {
+    "gdpr": {
+      "title": "GDPR-grunnlag",
+      "description": "Formål, samtykke, dataminimering, rettigheter",
+      "icon": "fas fa-scale-balanced"
+    },
+    "social": {
+      "title": "Sosial manipulering",
+      "description": "Phishing, pretexting, CEO-fraud",
+      "icon": "fas fa-user-secret"
+    },
+    "email": {
+      "title": "E-post & vedlegg",
+      "description": "Lenker, vedlegg, verifisering",
+      "icon": "fas fa-envelope"
+    },
+    "cookies": {
+      "title": "Cookies & samtykke",
+      "description": "Banner, nødvendighet, analyse/markedsføring",
+      "icon": "fas fa-cookie-bite"
+    }
+  },
+  "sections": [
+    {
+      "key": "s1_gdpr",
+      "title": "GDPR",
+      "description": "Formål, samtykke og rettigheter",
+      "order": 1,
+      "gating": null
+    },
+    {
+      "key": "s2_social",
+      "title": "Sosial manipulering",
+      "description": "Unngå å bli lurt",
+      "order": 2,
+      "gating": null
+    },
+    {
+      "key": "s3_email",
+      "title": "E-post",
+      "description": "Trygg håndtering i hverdagen",
+      "order": 3,
+      "gating": null
+    },
+    {
+      "key": "s4_cookies",
+      "title": "Cookies",
+      "description": "Samtykke og valg",
+      "order": 4,
+      "gating": null
+    }
+  ],
+  "assets": {
+    "images": [],
+    "attachments": [],
+    "references": []
+  },
+  "questions": [
+    {
+      "id": 1,
+      "section": "s1_gdpr",
+      "category": "gdpr",
+      "text": "Du vil sende nyhetsbrev til potensielle kunder som legger igjen e-post. Hva trenger du?",
+      "type": "single",
+      "weight": 4,
+      "time_limit_sec": null,
+      "difficulty_tag": "medium",
+      "cognitive_level": "apply",
+      "options": [
+        {
+          "label": "Gyldig, frivillig og spesifikt samtykke før utsendelse",
+          "value": "consent_specific",
+          "correct": true
+        },
+        {
+          "label": "Skjult samtykke i personvernerklæringen",
+          "value": "consent_hidden",
+          "correct": false
+        },
+        {
+          "label": "At de besøkte nettsiden din én gang",
+          "value": "visit_once",
+          "correct": false
+        }
+      ],
+      "feedback": "Markedsføring via e-post til ikke-kunder krever vanligvis gyldig samtykke. Samtykket skal være informert, frivillig og spesifikt.",
+      "hints": [
+        "Tenk på kravene i artikkel 6 og ePrivacy for kommunikasjon."
+      ],
+      "tags": [
+        "consent",
+        "marketing"
+      ],
+      "stats": {
+        "views": 0,
+        "attempts": 0,
+        "correct_rate": null,
+        "avg_time_sec": null,
+        "discrimination_pb": null,
+        "top_distractors": []
+      }
+    }
+  ],
+  "scoring": {
+    "single": {
+      "correct": "weight",
+      "incorrect": 0
+    },
+    "multiple": {
+      "method": "partial_credit",
+      "credit": "weight * (correct_selected / num_correct)",
+      "penalty": "weight * 0.5 * (incorrect_selected / num_incorrect)",
+      "clamp": [
+        0,
+        "weight"
+      ]
+    },
+    "true_false": {
+      "correct": "weight",
+      "incorrect": 0
+    },
+    "short_answer": {
+      "method": "keyword_match",
+      "min_keywords_for_full": 2,
+      "case_sensitive": false
+    },
+    "normalization": {
+      "max_score": null,
+      "scale_to_percentage": true
+    }
+  },
+  "result_buckets": [
+    {
+      "min_percentage": 0,
+      "label": "Starter",
+      "description": "God start – bygg grunnmur: samtykke, verifisering og cookie-valg."
+    },
+    {
+      "min_percentage": 40,
+      "label": "Bronse",
+      "description": "På vei – forbedre rutiner for verifisering, sletting og opplæring."
+    },
+    {
+      "min_percentage": 65,
+      "label": "Sølv",
+      "description": "Solid – standardiser maler, øvelser og tekniske kontroller."
+    },
+    {
+      "min_percentage": 85,
+      "label": "Gull",
+      "description": "Modent – kontinuerlig måling, revisjon og forbedring i hele kjeden."
+    }
+  ],
+  "analytics_spec": {
+    "events": [
+      "assessment_started",
+      "section_entered",
+      "question_viewed",
+      "answer_selected",
+      "answer_changed",
+      "hint_opened",
+      "question_flagged",
+      "assessment_submitted",
+      "assessment_passed",
+      "assessment_failed",
+      "assessment_abandoned"
+    ],
+    "dimensions": [
+      "section",
+      "category",
+      "device_type",
+      "browser",
+      "locale",
+      "acquisition_source"
+    ],
+    "metrics": [
+      "completion_rate",
+      "pass_rate",
+      "avg_score_pct",
+      "median_time_min",
+      "avg_attempts_to_pass",
+      "abandonment_rate",
+      "bounce_time_sec",
+      "question_correct_rate",
+      "question_avg_time_sec",
+      "item_difficulty_p",
+      "item_discrimination_pb",
+      "category_accuracy",
+      "category_time_spent_sec",
+      "dropoff_per_question",
+      "hint_usage_rate",
+      "flag_rate",
+      "tab_switch_count",
+      "conversion_to_signup_rate",
+      "conversion_to_purchase_rate"
+    ]
+  },
+  "kpi_targets": {
+    "completion_rate_pct": 70,
+    "pass_rate_pct": 60,
+    "avg_score_pct": 75,
+    "median_time_min": 10,
+    "abandonment_rate_pct": 15,
+    "avg_attempts_to_pass": 1.2,
+    "category_min_accuracy_pct": {
+      "gdpr": 60,
+      "social": 60,
+      "email": 60,
+      "cookies": 60
+    }
+  },
+  "computed_kpis": {
+    "time_window": {
+      "from": null,
+      "to": null
+    },
+    "overall": {
+      "starts": 0,
+      "completions": 0,
+      "completion_rate_pct": null,
+      "passes": 0,
+      "pass_rate_pct": null,
+      "avg_score_pct": null,
+      "median_time_min": null,
+      "avg_attempts_to_pass": null,
+      "abandonment_rate_pct": null,
+      "bounce_time_sec": null,
+      "reliability_kr20": null
+    },
+    "by_category": {
+      "gdpr": {
+        "accuracy_pct": null,
+        "avg_time_sec": null,
+        "attempts": 0
+      },
+      "social": {
+        "accuracy_pct": null,
+        "avg_time_sec": null,
+        "attempts": 0
+      },
+      "email": {
+        "accuracy_pct": null,
+        "avg_time_sec": null,
+        "attempts": 0
+      },
+      "cookies": {
+        "accuracy_pct": null,
+        "avg_time_sec": null,
+        "attempts": 0
+      }
+    },
+    "by_section": {
+      "s1_gdpr": {
+        "dropoff_pct": null,
+        "avg_time_sec": null
+      },
+      "s2_social": {
+        "dropoff_pct": null,
+        "avg_time_sec": null
+      },
+      "s3_email": {
+        "dropoff_pct": null,
+        "avg_time_sec": null
+      },
+      "s4_cookies": {
+        "dropoff_pct": null,
+        "avg_time_sec": null
+      }
+    },
+    "top_error_patterns": [
+      {
+        "question_id": null,
+        "common_wrong_option_value": null,
+        "rate_pct": null
+      }
+    ],
+    "device_locale_splits": {
+      "by_device": {
+        "desktop": 0,
+        "mobile": 0,
+        "tablet": 0
+      },
+      "by_locale": {
+        "nb-NO": 0,
+        "en-US": 0
+      }
+    }
+  },
+  "audit": {
+    "created_by": "admin_ekhana",
+    "created_at": "2025-09-23T10:00:00Z",
+    "updated_at": "2025-09-23T10:00:00Z",
+    "changelog": [
+      {
+        "version": "1.1.0",
+        "date": "2025-09-23T10:00:00Z",
+        "notes": "Added KPIs, security, UX, integrations, i18n."
+      }
+    ]
+  }
+}

--- a/src/app/assessment_templates/registry.py
+++ b/src/app/assessment_templates/registry.py
@@ -1,0 +1,51 @@
+"""Registry utilities for bundled assessment templates."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from functools import lru_cache
+from importlib import resources
+from types import MappingProxyType
+
+from app.schemas.assessment_template import (
+    AssessmentDefinition,
+    AssessmentTemplateSummary,
+)
+
+_TEMPLATE_FILES = MappingProxyType(
+    {
+        "course_gdpr_social_email_cookies_v1_no": "course_gdpr_social_email_cookies_v1_no.json",
+    }
+)
+
+
+@lru_cache(maxsize=1)
+def _load_registry() -> Mapping[str, AssessmentDefinition]:
+    """Load and validate all bundled template definitions."""
+
+    registry: dict[str, AssessmentDefinition] = {}
+    base_path = resources.files("app.assessment_templates.definitions")
+    for template_id, filename in _TEMPLATE_FILES.items():
+        data = base_path.joinpath(filename).read_text(encoding="utf-8")
+        registry[template_id] = AssessmentDefinition.model_validate_json(data)
+    return MappingProxyType(registry)
+
+
+def list_assessment_templates() -> list[AssessmentTemplateSummary]:
+    """Return summaries for all registered templates."""
+
+    return [
+        AssessmentTemplateSummary.from_definition(definition)
+        for definition in _load_registry().values()
+    ]
+
+
+def get_assessment_template(template_id: str) -> AssessmentDefinition | None:
+    """Retrieve a template definition by identifier, if present."""
+
+    return _load_registry().get(template_id)
+
+
+__all__ = [
+    "get_assessment_template",
+    "list_assessment_templates",
+]

--- a/src/app/schemas/assessment_template.py
+++ b/src/app/schemas/assessment_template.py
@@ -1,0 +1,346 @@
+"""Pydantic models for complete assessment template definitions."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AssessmentLinkage(BaseModel):
+    course_id: str = Field(..., description="Platform-wide course identifier")
+    module_id: str = Field(..., description="Module identifier within the course")
+    assessment_set_id: str = Field(..., description="Identifier of the assessment set the template belongs to")
+
+
+class AssessmentRegulatoryReference(BaseModel):
+    framework: str
+    article: str | None = None
+    topic: str | None = None
+
+
+class AssessmentMeta(BaseModel):
+    title: str
+    description: str
+    estimated_minutes: str
+    language: str
+    visibility: str
+    tags: list[str]
+    category: str
+    difficulty: str
+    audience: str
+    learning_objectives: list[str]
+    regulatory_refs: list[AssessmentRegulatoryReference]
+
+
+class AssessmentGateRules(BaseModel):
+    require_video_completion_percent: int
+    require_acknowledgement: bool
+
+
+class AssessmentSettings(BaseModel):
+    lead_magnet: bool
+    collect_fields: list[str]
+    shuffle_questions: bool
+    shuffle_options: bool
+    time_limit_minutes: int | None
+    allow_backtracking: bool
+    show_explanations: str
+    max_attempts_per_user: int
+    retake_cooldown_hours: int
+    pass_threshold_percentage: int
+    gate_rules: AssessmentGateRules
+
+
+class AssessmentAccessibility(BaseModel):
+    wcag_level: str
+    caption_required: bool
+    reading_grade_level: str
+
+
+class AssessmentLocalization(BaseModel):
+    default_locale: str
+    available_locales: list[str]
+
+
+class AssessmentUX(BaseModel):
+    theme: str
+    progress_bar: bool
+    question_numbering: str
+    accessibility: AssessmentAccessibility
+    localization: AssessmentLocalization
+
+
+class AssessmentAntiCheat(BaseModel):
+    tab_switch_limit: int
+    copy_paste_allowed: bool
+    suspicious_ip_threshold: int
+    allow_list_domains: list[str]
+
+
+class AssessmentProctoring(BaseModel):
+    enabled: bool
+    photo_check: bool
+
+
+class AssessmentDataProtection(BaseModel):
+    store_personal_fields_hashed: bool
+    retain_personal_days: int
+
+
+class AssessmentSecurity(BaseModel):
+    anti_cheat: AssessmentAntiCheat
+    proctoring: AssessmentProctoring
+    data_protection: AssessmentDataProtection
+
+
+class AssessmentWebhooks(BaseModel):
+    on_pass: str | None
+    on_fail: str | None
+    on_completion: str | None
+
+
+class AssessmentLMS(BaseModel):
+    scorm: bool
+    xapi: bool
+
+
+class AssessmentPayments(BaseModel):
+    enabled: bool
+    currency: str
+    price_amount: int | float
+    sku: str
+    is_free: bool
+
+
+class AssessmentIntegrations(BaseModel):
+    webhooks: AssessmentWebhooks
+    lms: AssessmentLMS
+    payments: AssessmentPayments
+
+
+class AssessmentCategoryDefinition(BaseModel):
+    title: str
+    description: str
+    icon: str
+
+
+class AssessmentSection(BaseModel):
+    key: str
+    title: str
+    description: str
+    order: int
+    gating: str | None
+
+
+class AssessmentAssets(BaseModel):
+    images: list[str]
+    attachments: list[str]
+    references: list[str]
+
+
+class AssessmentQuestionOption(BaseModel):
+    label: str
+    value: str
+    correct: bool
+
+
+class AssessmentQuestionStats(BaseModel):
+    views: int
+    attempts: int
+    correct_rate: float | None
+    avg_time_sec: float | None
+    discrimination_pb: float | None
+    top_distractors: list[str]
+
+
+class AssessmentQuestion(BaseModel):
+    id: int
+    section: str
+    category: str
+    text: str
+    type: str
+    weight: int | float
+    time_limit_sec: int | None
+    difficulty_tag: str
+    cognitive_level: str
+    options: list[AssessmentQuestionOption]
+    feedback: str
+    hints: list[str]
+    tags: list[str]
+    stats: AssessmentQuestionStats
+
+
+class AssessmentScoringSingle(BaseModel):
+    correct: str
+    incorrect: int | float
+
+
+class AssessmentScoringMultiple(BaseModel):
+    method: str
+    credit: str
+    penalty: str
+    clamp: list[int | float | str]
+
+
+class AssessmentScoringTrueFalse(BaseModel):
+    correct: str
+    incorrect: int | float
+
+
+class AssessmentScoringShortAnswer(BaseModel):
+    method: str
+    min_keywords_for_full: int
+    case_sensitive: bool
+
+
+class AssessmentScoringNormalization(BaseModel):
+    max_score: int | float | None
+    scale_to_percentage: bool
+
+
+class AssessmentScoring(BaseModel):
+    single: AssessmentScoringSingle
+    multiple: AssessmentScoringMultiple
+    true_false: AssessmentScoringTrueFalse
+    short_answer: AssessmentScoringShortAnswer
+    normalization: AssessmentScoringNormalization
+
+
+class AssessmentResultBucket(BaseModel):
+    min_percentage: int
+    label: str
+    description: str
+
+
+class AssessmentAnalyticsSpec(BaseModel):
+    events: list[str]
+    dimensions: list[str]
+    metrics: list[str]
+
+
+class AssessmentKpiTargets(BaseModel):
+    completion_rate_pct: int
+    pass_rate_pct: int
+    avg_score_pct: int
+    median_time_min: int
+    abandonment_rate_pct: int
+    avg_attempts_to_pass: float
+    category_min_accuracy_pct: dict[str, int]
+
+
+class AssessmentTimeWindow(BaseModel):
+    from_: datetime | None = Field(default=None, alias="from")
+    to: datetime | None = None
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class AssessmentOverallKpi(BaseModel):
+    starts: int
+    completions: int
+    completion_rate_pct: float | None
+    passes: int
+    pass_rate_pct: float | None
+    avg_score_pct: float | None
+    median_time_min: float | None
+    avg_attempts_to_pass: float | None
+    abandonment_rate_pct: float | None
+    bounce_time_sec: float | None
+    reliability_kr20: float | None
+
+
+class AssessmentCategoryKpi(BaseModel):
+    accuracy_pct: float | None
+    avg_time_sec: float | None
+    attempts: int
+
+
+class AssessmentSectionKpi(BaseModel):
+    dropoff_pct: float | None
+    avg_time_sec: float | None
+
+
+class AssessmentErrorPattern(BaseModel):
+    question_id: int | None
+    common_wrong_option_value: str | None
+    rate_pct: float | None
+
+
+class AssessmentDeviceLocaleSplits(BaseModel):
+    by_device: dict[str, int]
+    by_locale: dict[str, int]
+
+
+class AssessmentComputedKpis(BaseModel):
+    time_window: AssessmentTimeWindow
+    overall: AssessmentOverallKpi
+    by_category: dict[str, AssessmentCategoryKpi]
+    by_section: dict[str, AssessmentSectionKpi]
+    top_error_patterns: list[AssessmentErrorPattern]
+    device_locale_splits: AssessmentDeviceLocaleSplits
+
+
+class AssessmentAuditChange(BaseModel):
+    version: str
+    date: datetime
+    notes: str
+
+
+class AssessmentAudit(BaseModel):
+    created_by: str
+    created_at: datetime
+    updated_at: datetime
+    changelog: list[AssessmentAuditChange]
+
+
+class AssessmentDefinition(BaseModel):
+    id: str
+    version: str
+    org_id: str
+    linkage: AssessmentLinkage
+    meta: AssessmentMeta
+    settings: AssessmentSettings
+    ux: AssessmentUX
+    security: AssessmentSecurity
+    integrations: AssessmentIntegrations
+    categories: dict[str, AssessmentCategoryDefinition]
+    sections: list[AssessmentSection]
+    assets: AssessmentAssets
+    questions: list[AssessmentQuestion]
+    scoring: AssessmentScoring
+    result_buckets: list[AssessmentResultBucket]
+    analytics_spec: AssessmentAnalyticsSpec
+    kpi_targets: AssessmentKpiTargets
+    computed_kpis: AssessmentComputedKpis
+    audit: AssessmentAudit
+
+
+class AssessmentTemplateSummary(BaseModel):
+    """Concise view that can be used to populate template selectors."""
+
+    id: str
+    version: str
+    title: str
+    category: str
+    difficulty: str
+    estimated_minutes: str
+    tags: list[str]
+
+    @classmethod
+    def from_definition(cls, definition: AssessmentDefinition) -> AssessmentTemplateSummary:
+        meta = definition.meta
+        return cls(
+            id=definition.id,
+            version=definition.version,
+            title=meta.title,
+            category=meta.category,
+            difficulty=meta.difficulty,
+            estimated_minutes=meta.estimated_minutes,
+            tags=meta.tags,
+        )
+
+
+__all__ = [
+    "AssessmentDefinition",
+    "AssessmentTemplateSummary",
+]

--- a/tests/test_assessment_templates.py
+++ b/tests/test_assessment_templates.py
@@ -1,0 +1,42 @@
+from fastapi.testclient import TestClient
+
+from app.assessment_templates import (
+    get_assessment_template,
+    list_assessment_templates,
+)
+
+TEMPLATE_ID = "course_gdpr_social_email_cookies_v1_no"
+
+
+def test_list_assessment_templates(client: TestClient) -> None:
+    response = client.get("/api/v1/assessment/schema")
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert isinstance(payload, list)
+    assert any(item["id"] == TEMPLATE_ID for item in payload)
+
+
+def test_get_assessment_template_detail(client: TestClient) -> None:
+    response = client.get(f"/api/v1/assessment/schema/{TEMPLATE_ID}")
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["id"] == TEMPLATE_ID
+    assert payload["meta"]["title"].startswith("Kurs: GDPR")
+    assert payload["computed_kpis"]["time_window"]["from"] is None
+
+
+def test_get_assessment_template_not_found(client: TestClient) -> None:
+    response = client.get("/api/v1/assessment/schema/unknown")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Assessment template not found"
+
+
+def test_registry_exposes_bundled_template() -> None:
+    summaries = list_assessment_templates()
+    assert any(summary.id == TEMPLATE_ID for summary in summaries)
+
+    definition = get_assessment_template(TEMPLATE_ID)
+    assert definition is not None
+    assert definition.meta.category == "GDPR & Sikkerhet"


### PR DESCRIPTION
## Summary
- refactor the assessment template registry to load JSON definitions from `app/assessment_templates` and expose typed helpers
- keep the schema endpoints and tests aligned with the new registry utilities
- refresh the SPOT documentation and changelog entries to point at the new layout

## Testing
- PYTHONPATH=src pytest tests/test_assessment_templates.py -q *(fails: Redis service not available in test environment)*
- ruff check src/app/assessment_templates/registry.py tests/test_assessment_templates.py

------
https://chatgpt.com/codex/tasks/task_b_68d3d17e91648328a2a22b4e8d0b4e1f